### PR TITLE
Add in better hooks for moving assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/firefox-webext-browser": "^82.0.0",
     "@types/fs-extra": "^9.0.11",
     "@types/jest": "^26.0.23",
+    "@types/klaw": "^3.0.2",
     "@types/node": "^16.0.0",
     "@types/webpack": "4",
     "@types/ws": "^7.4.6",
@@ -38,6 +39,7 @@
   },
   "dependencies": {
     "fs-extra": "^10.0.0",
+    "klaw": "^3.0.0",
     "webpack-inject-plugin": "^1.5.5",
     "ws": "^7.5.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1231,6 +1231,13 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/klaw@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/klaw/-/klaw-3.0.2.tgz#ce9cf2c0566b806d4fe86eb07082b483ad1ee3f6"
+  integrity sha512-v8smJUQ5SuoCh1EZ5B429DTGFDE0URnC9ix3wJpTB8Ofk7Rgi5Hj/jm9GffavHiXPeYgPRe3ASBfB6LT6ytceg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*", "@types/node@^16.0.0":
   version "16.0.0"
   resolved "https://registry.npmjs.org/@types/node/-/node-16.0.0.tgz#067a6c49dc7a5c2412a505628e26902ae967bf6f"
@@ -1977,7 +1984,7 @@ globals@^11.1.0:
   resolved "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
+graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
@@ -2663,6 +2670,13 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+klaw@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-3.0.0.tgz#b11bec9cf2492f06756d6e809ab73a2910259146"
+  integrity sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==
+  dependencies:
+    graceful-fs "^4.1.9"
 
 kleur@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
## Description

This PR updates the hooks used to move files over to the output directory. This makes these files assets of webpack and more compatible with the rest of the build process.

This still does not seem to work with `zip-webpack-plugin` and still need to verify the `clean-webpack-plugin`, but overall this feels like a good first step.
